### PR TITLE
update PN54x compatibility symlinks

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -341,7 +341,8 @@ on boot
     mkdir /data/nfc/param 0770 nfc nfc
 
     # Symlink for compability
-    symlink /dev/pn547 /dev/pn544
+    symlink /dev/pn54x /dev/pn544
+    symlink /dev/pn54x /dev/pn547
 
     # Set the console loglevel to < KERN_INFO
     # Set the default message loglevel to KERN_INFO

--- a/rootdir/ueventd.kitakami.rc
+++ b/rootdir/ueventd.kitakami.rc
@@ -114,6 +114,7 @@
 /dev/nfc-nci                                        0660 nfc nfc
 /dev/pn544                                          0660 nfc nfc
 /dev/pn547                                          0660 nfc nfc
+/dev/pn54x                                          0660 nfc nfc
 /sys/devices/f9928000.i2c/i2c-6/6-0028  init_deinit 0200 nfc nfc
 /sys/devices/f9928000.i2c/i2c-6/6-0028  set_pwr     0200 nfc nfc
 /sys/devices/f9928000.i2c/i2c-6/6-0028  res_ready   0400 nfc nfc


### PR DESCRIPTION
new NFC HAL uses generic /dev/pn54x while old one uses /dev/pn547
this change enshures compatibility for both cases

Signed-off-by: Alin Jerpelea alin.jerpelea@sonymobile.com
