### PR TITLE
kitakami: Fix build with GCC

### DIFF
--- a/display/libhwcomposer/hwc_vsync.cpp
+++ b/display/libhwcomposer/hwc_vsync.cpp
@@ -64,7 +64,7 @@ static void handle_vsync_event(hwc_context_t* ctx, int dpy, char *data)
         timestamp = strtoull(data + strlen("VSYNC="), NULL, 0);
     }
     // send timestamp to SurfaceFlinger
-    ALOGD_IF (ctx->vstate.debug, "%s: timestamp %"PRIu64" sent to SF for dpy=%d",
+    ALOGD_IF (ctx->vstate.debug, "%s: timestamp %" PRIu64" sent to SF for dpy=%d",
             __FUNCTION__, timestamp, dpy);
     ctx->proc->vsync(ctx->proc, dpy, timestamp);
 }
@@ -89,7 +89,7 @@ static void handle_thermal_event(hwc_context_t* ctx, int dpy, char *data)
     }
 
     if (thermalLevel >= MAX_THERMAL_LEVEL) {
-        ALOGD("%s: dpy:%d thermal_level=%"PRIu64"",__FUNCTION__,dpy,thermalLevel);
+        ALOGD("%s: dpy:%d thermal_level=%" PRIu64"",__FUNCTION__,dpy,thermalLevel);
         ctx->mThermalBurstMode = true;
     } else
         ctx->mThermalBurstMode = false;

--- a/display/libqdutils/profiler.cpp
+++ b/display/libqdutils/profiler.cpp
@@ -107,7 +107,7 @@ void CalcFps::populate_debug_fps_metadata(void)
     debug_fps_metadata.curr_frame = 0;
 
     ALOGD("period: %u", debug_fps_metadata.period);
-    ALOGD("ignorethresh_us: %"PRId64, debug_fps_metadata.ignorethresh_us);
+    ALOGD("ignorethresh_us: %" PRId64, debug_fps_metadata.ignorethresh_us);
 }
 
 void CalcFps::print_fps(float fps)
@@ -127,7 +127,7 @@ void CalcFps::print_fps(float fps)
         for (unsigned int i = 0;
              i < ((debug_fps_metadata.framearrival_steps / 6) + 1);
              i++) {
-            ALOGD("%"PRId64" %"PRId64" %"PRId64" %"PRId64" %"PRId64" %"PRId64,
+            ALOGD("%" PRId64" %" PRId64" %" PRId64" %" PRId64" %" PRId64" %" PRId64,
                   debug_fps_metadata.accum_framearrivals[i*6],
                   debug_fps_metadata.accum_framearrivals[i*6+1],
                   debug_fps_metadata.accum_framearrivals[i*6+2],


### PR DESCRIPTION
since C++11 introduced user-defined literals then
this patch adds spaces between string literals and macros
and fix build process using GCC

error: unable to find string literal operator 'operator"" PRId64'

Signed-off-by: Humberto Borba humberos@gmail.com
