### PR TITLE
kitakami: ueventd: remove deprecated camera permissions

### DIFF
--- a/rootdir/ueventd.kitakami.rc
+++ b/rootdir/ueventd.kitakami.rc
@@ -139,5 +139,3 @@
 /sys/devices/virtual/graphics/fb1/product_description 0664 system graphics
 /sys/devices/virtual/graphics/fb1/hdcp/tp             0664 system graphics
 /sys/devices/virtual/graphics/fb2/ad                  0664 system graphics
-/sys/devices/sony_camera_0/info                       0666 camera camera
-/sys/devices/sony_camera_1/info                       0666 camera camera


### PR DESCRIPTION
following commit: 2fcb20328d014ce289cc349b0051a16d85adf149

Signed-off-by: David Viteri davidteri91@gmail.com
