### PR TITLE
kitakami: update mediasettings elements

### DIFF
--- a/rootdir/system/etc/media_profiles.xml
+++ b/rootdir/system/etc/media_profiles.xml
@@ -23,9 +23,7 @@
                          VideoEncoderCap+,
                          AudioEncoderCap+,
                          VideoDecoderCap,
-                         AudioDecoderCap,
-                         VideoEditorCap,
-                         ExportVideoProfile)>
+                         AudioDecoderCap)>
 <!ELEMENT CamcorderProfiles (EncoderProfile+, ImageEncoding+, ImageDecoding, Camera)>
 <!ELEMENT EncoderProfile (Video, Audio)>
 <!ATTLIST EncoderProfile quality (timelapse1080p|timelapse720p|timelapse480p|timelapsehigh|timelapselow|480p|qcif|high|low) #REQUIRED>


### PR DESCRIPTION
remove VideoEditorCap & ExportVideoProfile those were removed on commits: cdfbec32c71e2ec9777d9e6e0c43ca688e5c5e01 & fa9f4f68a1e5941d43f112c2c0b22e7fc887669d

Signed-off-by: David Viteri davidteri91@gmail.com
