### PR TITLE
kitakami: compile new AOSP messaging app

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -201,9 +201,11 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     charger_res_images
 
+# AOSP Packages
 PRODUCT_PACKAGES += \
     InCallUI \
-    Launcher3
+    Launcher3 \
+    messaging
 
 PRODUCT_PACKAGES += \
     libemoji


### PR DESCRIPTION
all targets (ivy karin/windy sumire and suzuran) are tracking aosp_base.mk & telephony.mk
well those are not including this: https://android.googlesource.com/platform/build/+/f29b5bd380e5ecced9bfa1d241e8b47448c29040%5E%21/#F
which let's without proper mms app on AOSP... so include it on our commons

Signed-off-by: David Viteri davidteri91@gmail.com
