### PR TITLE
kitakami: Fix dynamic linker for boringssl-compat

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -22,7 +22,7 @@ on init
     symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
 
     # BoringSSL hacks
-    export LD_PRELOAD "/system/lib64/libboringssl-compat.so"
+    export LD_PRELOAD "libboringssl-compat.so"
 
     mkdir /dev/bus 0755 root root
     mkdir /dev/bus/usb 0755 root root


### PR DESCRIPTION
Remove full arch path and call only lib name then the system
will preload it correctly.

Signed-off-by: Humberto Borba humberos@gmail.com
