### PR TITLE
Seems to be a typo error.

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -67,7 +67,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.midi.xml:system/etc/permissions/android.software.midi.xml
 
 PRODUCT_COPY_FILES += \
-    $(SONY_ROOT)/system/etc/audio_effects.conf:system/vendor/etc/audio_effects.conf \
+    $(SONY_ROOT)/system/etc/audio_effects.conf:system/etc/audio_effects.conf \
     $(SONY_ROOT)/system/etc/audio_policy.conf:system/etc/audio_policy.conf \
     $(SONY_ROOT)/system/etc/media_codecs.xml:system/etc/media_codecs.xml \
     $(SONY_ROOT)/system/etc/media_profiles.xml:system/etc/media_profiles.xml \

--- a/device.mk
+++ b/device.mk
@@ -110,7 +110,7 @@ PRODUCT_PACKAGES += \
     libtinyalsa \
     libtinycompress \
     libaudioroute \
-    tinymix \
+    tinymix
 
 # Audio effects
 PRODUCT_PACKAGES += \

--- a/device.mk
+++ b/device.mk
@@ -217,7 +217,7 @@ PRODUCT_PACKAGES += \
 # APN list
 PRODUCT_COPY_FILES += \
     device/sample/etc/old-apns-conf.xml:system/etc/old-apns-conf.xml \
-    device/sample/etc/apns-full-conf.xml:system/etc/apns-conf.xml
+    device/sample/etc/apns-full-conf.xml:system/etc/apns-full-conf.xml
 
 # Bluetooth
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
Delete a \ character in audio.primary.msm8994 line

Signed-off-by: Javier Romero xavinux@gmail.com
