### PR TITLE
kitakami: fix typo

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -109,7 +109,7 @@ PRODUCT_PACKAGES += \
     libtinyalsa \
     libtinycompress \
     libaudioroute \
-    tinymix \
+    tinymix
 
 # Audio effects
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
it was introduced from initial commit: bbb955a633643ec2e2916553eef466b8e1097f7e

Signed-off-by: David Viteri davidteri91@gmail.com
