### PR TITLE
kitakami: fix typo

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -109,7 +109,7 @@ PRODUCT_PACKAGES += \
     libtinyalsa \
     libtinycompress \
     libaudioroute \
-    tinymix \
+    tinymix
 
 # Audio effects
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
it was introduced from initial commit: 88417c2f52536452881740961e2cd1ab737bfebf

Signed-off-by: David Viteri davidteri91@gmail.com
