### PR TITLE
kitakami: remove SONY_ROOT define

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -12,34 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SONY_ROOT = device/sony/kitakami/rootdir
-
 SOMC_PLATFORM := kitakami
 
 DEVICE_PACKAGE_OVERLAYS += \
     device/sony/kitakami/overlay
 
 PRODUCT_COPY_FILES += \
-    $(SONY_ROOT)/fstab.kitakami:root/fstab.kitakami \
-    $(SONY_ROOT)/system/usr/idc/clearpad.idc:system/usr/idc/clearpad.idc \
-    $(SONY_ROOT)/system/usr/idc/touch_fusion.idc:system/usr/idc/touch_fusion.idc \
-    $(SONY_ROOT)/system/etc/aanc_tuning_mixer.txt:system/etc/aanc_tuning_mixer.txt \
-    $(SONY_ROOT)/system/etc/audio_platform_info.xml:system/etc/audio_platform_info.xml \
-    $(SONY_ROOT)/system/etc/audio_platform_info_i2s.xml:system/etc/audio_platform_info_i2s.xml \
-    $(SONY_ROOT)/system/etc/bluetooth/bt_vendor.conf:system/etc/bluetooth/bt_vendor.conf \
-    $(SONY_ROOT)/system/etc/sensors_settings:system/etc/sensors_settings \
-    $(SONY_ROOT)/system/etc/sec_config:system/etc/sec_config \
-    $(SONY_ROOT)/system/etc/gps.conf:system/etc/gps.conf
+    device/sony/kitakami/rootdir/fstab.kitakami:root/fstab.kitakami \
+    device/sony/kitakami/rootdir/system/usr/idc/clearpad.idc:system/usr/idc/clearpad.idc \
+    device/sony/kitakami/rootdir/system/usr/idc/touch_fusion.idc:system/usr/idc/touch_fusion.idc \
+    device/sony/kitakami/rootdir/system/etc/aanc_tuning_mixer.txt:system/etc/aanc_tuning_mixer.txt \
+    device/sony/kitakami/rootdir/system/etc/audio_platform_info.xml:system/etc/audio_platform_info.xml \
+    device/sony/kitakami/rootdir/system/etc/audio_platform_info_i2s.xml:system/etc/audio_platform_info_i2s.xml \
+    device/sony/kitakami/rootdir/system/etc/bluetooth/bt_vendor.conf:system/etc/bluetooth/bt_vendor.conf \
+    device/sony/kitakami/rootdir/system/etc/sensors_settings:system/etc/sensors_settings \
+    device/sony/kitakami/rootdir/system/etc/sec_config:system/etc/sec_config \
+    device/sony/kitakami/rootdir/system/etc/gps.conf:system/etc/gps.conf
 
 PRODUCT_COPY_FILES += \
-    $(SONY_ROOT)/init.recovery.kitakami.rc:root/init.recovery.kitakami.rc \
-    $(SONY_ROOT)/init.recovery.kitakami.rc:root/init.recovery.kitakami64_32.rc \
-    $(SONY_ROOT)/init.kitakami.rc:root/init.kitakami.rc \
-    $(SONY_ROOT)/init.kitakami.rc:root/init.kitakami64_32.rc \
-    $(SONY_ROOT)/init.kitakami.usb.rc:root/init.kitakami.usb.rc \
-    $(SONY_ROOT)/init.kitakami.pwr.rc:root/init.kitakami.pwr.rc \
-    $(SONY_ROOT)/ueventd.kitakami.rc:root/ueventd.kitakami.rc \
-    $(SONY_ROOT)/ueventd.kitakami.rc:root/ueventd.kitakami64_32.rc
+    device/sony/kitakami/rootdir/init.recovery.kitakami.rc:root/init.recovery.kitakami.rc \
+    device/sony/kitakami/rootdir/init.recovery.kitakami.rc:root/init.recovery.kitakami64_32.rc \
+    device/sony/kitakami/rootdir/init.kitakami.rc:root/init.kitakami.rc \
+    device/sony/kitakami/rootdir/init.kitakami.rc:root/init.kitakami64_32.rc \
+    device/sony/kitakami/rootdir/init.kitakami.usb.rc:root/init.kitakami.usb.rc \
+    device/sony/kitakami/rootdir/init.kitakami.pwr.rc:root/init.kitakami.pwr.rc \
+    device/sony/kitakami/rootdir/ueventd.kitakami.rc:root/ueventd.kitakami.rc \
+    device/sony/kitakami/rootdir/ueventd.kitakami.rc:root/ueventd.kitakami64_32.rc
 
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.audio.low_latency.xml:system/etc/permissions/android.hardware.audio.low_latency.xml \
@@ -67,29 +65,29 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.midi.xml:system/etc/permissions/android.software.midi.xml
 
 PRODUCT_COPY_FILES += \
-    $(SONY_ROOT)/system/etc/audio_effects.conf:system/vendor/etc/audio_effects.conf \
-    $(SONY_ROOT)/system/etc/media_codecs.xml:system/etc/media_codecs.xml \
-    $(SONY_ROOT)/system/etc/media_profiles.xml:system/etc/media_profiles.xml \
-    $(SONY_ROOT)/system/etc/audio_platform_info.xml:system/etc/audio_platform_info.xml \
+    device/sony/kitakami/rootdir/system/etc/audio_effects.conf:system/vendor/etc/audio_effects.conf \
+    device/sony/kitakami/rootdir/system/etc/media_codecs.xml:system/etc/media_codecs.xml \
+    device/sony/kitakami/rootdir/system/etc/media_profiles.xml:system/etc/media_profiles.xml \
+    device/sony/kitakami/rootdir/system/etc/audio_platform_info.xml:system/etc/audio_platform_info.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_telephony.xml:system/etc/media_codecs_google_telephony.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml
 
 # NFC
 PRODUCT_COPY_FILES += \
-    $(SONY_ROOT)/system/etc/nfcee_access.xml:system/etc/nfcee_access.xml \
+    device/sony/kitakami/rootdir/system/etc/nfcee_access.xml:system/etc/nfcee_access.xml \
     frameworks/native/data/etc/android.hardware.nfc.xml:system/etc/permissions/android.hardware.nfc.xml \
     frameworks/native/data/etc/android.hardware.nfc.hce.xml:system/etc/permissions/android.hardware.nfc.hce.xml \
     frameworks/native/data/etc/com.android.nfc_extras.xml:system/etc/permissions/com.android.nfc_extras.xml
 
 # Keylayout
 PRODUCT_COPY_FILES += \
-    $(SONY_ROOT)/system/usr/keylayout/clearpad.kl:system/usr/keylayout/clearpad.kl \
-    $(SONY_ROOT)/system/usr/keylayout/gpio-keys.kl:system/usr/keylayout/gpio-keys.kl \
-    $(SONY_ROOT)/system/usr/keylayout/mhl-rcp.kl:system/usr/keylayout/mhl-rcp.kl \
-    $(SONY_ROOT)/system/usr/keylayout/msm8994-tomtom-snd-card_Button_Jack.kl:system/usr/keylayout/msm8994-tomtom-snd-card_Button_Jack.kl \
-    $(SONY_ROOT)/system/usr/keylayout/synaptics_dsx.kl:system/usr/keylayout/synaptics_dsx.kl \
-    $(SONY_ROOT)/system/usr/keylayout/touch_fusion.kl:system/usr/keylayout/touch_fusion.kl
+    device/sony/kitakami/rootdir/system/usr/keylayout/clearpad.kl:system/usr/keylayout/clearpad.kl \
+    device/sony/kitakami/rootdir/system/usr/keylayout/gpio-keys.kl:system/usr/keylayout/gpio-keys.kl \
+    device/sony/kitakami/rootdir/system/usr/keylayout/mhl-rcp.kl:system/usr/keylayout/mhl-rcp.kl \
+    device/sony/kitakami/rootdir/system/usr/keylayout/msm8994-tomtom-snd-card_Button_Jack.kl:system/usr/keylayout/msm8994-tomtom-snd-card_Button_Jack.kl \
+    device/sony/kitakami/rootdir/system/usr/keylayout/synaptics_dsx.kl:system/usr/keylayout/synaptics_dsx.kl \
+    device/sony/kitakami/rootdir/system/usr/keylayout/touch_fusion.kl:system/usr/keylayout/touch_fusion.kl
 
 # Audio
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Google doesn't use this simplified way

Change-Id: Ib0bb63bd9b80c145ccb1ac88bbf5af25c52dab9c
