### PR TITLE
kitakami: init: Add missed links for recovery mode

### DIFF
--- a/rootdir/init.recovery.kitakami.rc
+++ b/rootdir/init.recovery.kitakami.rc
@@ -1,4 +1,7 @@
-on boot
+on init
+    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
+    symlink /system/vendor /vendor
 
+on boot
     write /sys/class/android_usb/android0/idVendor 0FCE
     write /sys/class/android_usb/android0/idProduct 6${ro.usb.pid_suffix}


### PR DESCRIPTION
This patch fix mount process since fstab is using /dev/block/bootdevice link
Also, karin touch screen needs some stuff from vendor.

Signed-off-by: Humberto Borba humberos@gmail.com
