### PR TITLE
kitakami: init: Add missed link for recovery mode

### DIFF
--- a/rootdir/init.recovery.kitakami.rc
+++ b/rootdir/init.recovery.kitakami.rc
@@ -1,4 +1,6 @@
-on boot
+on init
+    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
 
+on boot
     write /sys/class/android_usb/android0/idVendor 0FCE
     write /sys/class/android_usb/android0/idProduct 6${ro.usb.pid_suffix}


### PR DESCRIPTION
This patch fix mount process since fstab is using /dev/block/bootdevice link

Signed-off-by: Humberto Borba humberos@gmail.com
