### PR TITLE
Revert "disable dexpreopt on 64bit targets"

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -118,6 +118,11 @@ NFC_NXP_CHIP_TYPE := PN547C2
 # Include an expanded selection of fonts
 EXTENDED_FONT_FOOTPRINT := true
 
+# Enable dex-preoptimization to speed up first boot sequence
+ifeq ($(HOST_OS),linux)
+    WITH_DEXPREOPT ?= true
+endif
+
 BUILD_KERNEL := true
 -include vendor/sony/kernel/KernelConfig.mk
 


### PR DESCRIPTION
This reverts commit c320425970ec7af53a6d096c134013bee1f2b4aa.
