### PR TITLE
kitakami: Force Android background tasks on A53s

### DIFF
--- a/rootdir/init.kitakami.pwr.rc
+++ b/rootdir/init.kitakami.pwr.rc
@@ -113,6 +113,10 @@ on property:init.svc.bootanim=stopped
     # Enable task migration fixups in the scheduler
     write /proc/sys/kernel/sched_migration_fixup 1
 
+    # Android background processes are set to nice 10
+    # Never schedule these on the A57
+    write /proc/sys/kernel/sched_upmigrate_min_nice 9
+
     #enable rps static configuration
     write /sys/class/net/rmnet_ipa0/queues/rx-0/rps_cpus 0
     write /proc/sys/kernel/sched_small_task 30


### PR DESCRIPTION
Set sched_upmigrate_min_nice to 9, instead of the default 15. The
"background" priority level in android is nice 10, so this setting will
prevent these processes from up-migrating.

Change-Id: Ifa99f3876c7aa8c2483f0dc3657133911f9ada81
