### PR TITLE
kitakami: Use the real name of partitions paths

### DIFF
--- a/rootdir/fstab.kitakami
+++ b/rootdir/fstab.kitakami
@@ -2,13 +2,13 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/bootdevice/by-name/system     /system            ext4    ro,barrier=1,discard                                        wait
-/dev/block/bootdevice/by-name/userdata   /data              ext4    nosuid,nodev,noatime,barrier=1,noauto_da_alloc,discard      wait,check,encryptable=footer
-/dev/block/bootdevice/by-name/cache      /cache             ext4    nosuid,nodev,noatime,barrier=1,discard                      wait,check
-/dev/block/bootdevice/by-name/boot       /boot              emmc    defaults                                                    defaults
-/dev/block/bootdevice/by-name/recovery   /recovery          emmc    defaults                                                    defaults
-/dev/block/bootdevice/by-name/config     /persistent        emmc    defaults                                                    defaults
-/dev/block/bootdevice/by-name/modem      /firmware          vfat    defaults                                                    defaults
+/dev/block/platform/soc.0/f9824900.sdhci/by-name/system     /system            ext4    ro,barrier=1,discard                                        wait
+/dev/block/platform/soc.0/f9824900.sdhci/by-name/userdata   /data              ext4    nosuid,nodev,noatime,barrier=1,noauto_da_alloc,discard      wait,check,encryptable=footer
+/dev/block/platform/soc.0/f9824900.sdhci/by-name/cache      /cache             ext4    nosuid,nodev,noatime,barrier=1,discard                      wait,check
+/dev/block/platform/soc.0/f9824900.sdhci/by-name/boot       /boot              emmc    defaults                                                    defaults
+/dev/block/platform/soc.0/f9824900.sdhci/by-name/recovery   /recovery          emmc    defaults                                                    defaults
+/dev/block/platform/soc.0/f9824900.sdhci/by-name/config     /persistent        emmc    defaults                                                    defaults
+/dev/block/platform/soc.0/f9824900.sdhci/by-name/modem      /firmware          vfat    defaults                                                    defaults
 
 /devices/soc.0/f98a4900.sdhci/mmc_host                       auto   vfat    nosuid,nodev                            voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/soc.0/f9a55000.ehci/usb1                            auto   vfat    nosuid,nodev                            voldmanaged=uicc0:auto

--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -19,8 +19,6 @@ on early-init
     mount debugfs debugfs /sys/kernel/debug
 
 on init
-    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
-
     # BoringSSL hacks
     export LD_PRELOAD "libboringssl-compat.so"
 
@@ -103,7 +101,7 @@ on post-fs-data
     write /data/system/sensors/settings 1
     chmod 664 /data/system/sensors/settings
 
-    chown system /dev/block/bootdevice/by-name
+    chown system /dev/block/platform/soc.0/f9824900.sdhci/by-name
 
     # Permissions for mpdecision and thermald
     mkdir /dev/socket/mpdecision 0770 system system
@@ -116,8 +114,8 @@ on post-fs-data
 
 on charger
     # Booting modem
-    wait /dev/block/bootdevice/by-name/system
-    mount ext4 /dev/block/bootdevice/by-name/system /system ro barrier=1
+    wait /dev/block/platform/soc.0/f9824900.sdhci/by-name/system
+    mount ext4 /dev/block/platform/soc.0/f9824900.sdhci/by-name/system /system ro barrier=1
     start rmt_storage
     start irsc_util
 
@@ -307,7 +305,7 @@ on boot
     write /sys/bus/msm_subsys/devices/subsys3/restart_level "related"
 
 # SONY misc
-service tad_static /system/vendor/bin/tad_static /dev/block/bootdevice/by-name/TA 0,16
+service tad_static /system/vendor/bin/tad_static /dev/block/platform/soc.0/f9824900.sdhci/by-name/TA 0,16
     user root
     group root
     socket tad stream 0660 system system


### PR DESCRIPTION
Use the real name of partitions paths instead of symlink then avoid
link creations over init files.

Signed-off-by: Humberto Borba humberos@gmail.com
