### PR TITLE
kitakami: sepolicy: don't label wcnss_service

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -26,6 +26,5 @@
 /system/vendor/bin/qmuxd                      u:object_r:qmuxd_exec:s0
 /system/vendor/bin/rmt_storage                u:object_r:rmt_storage_exec:s0
 /system/vendor/bin/sensors.qcom               u:object_r:sensors_exec:s0
-/system/vendor/bin/wcnss_service              u:object_r:wcnss_service_exec:s0
 
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0


### PR DESCRIPTION
it is exclusive of yukon and kanuti on aosp
https://github.com/sonyxperiadev/device-sony-yukon/blob/l-mr1/rootdir/init.yukon.rc#L365
https://github.com/sonyxperiadev/device-sony-kanuti/blob/l-mr1/rootdir/init.kanuti.rc#L393

Signed-off-by: David Viteri davidteri91@gmail.com
