### PR TITLE
Remove SeLinux context already defined by qcom

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -5,9 +5,6 @@
 /dev/pn54x                             u:object_r:nfc_device:s0
 
 # Block devices
-/dev/block/bootdevice/by-name/modemst1          u:object_r:modem_efs_partition_device:s0
-/dev/block/bootdevice/by-name/modemst2          u:object_r:modem_efs_partition_device:s0
-/dev/block/bootdevice/by-name/fsg               u:object_r:modem_efs_partition_device:s0
 /dev/block/bootdevice/by-name/TA                u:object_r:trim_area_partition_device:s0
 
 /data/etc/bluetooth_bdaddr             u:object_r:addrsetup_data_file:s0


### PR DESCRIPTION
Context for modemst1, modemst2 and fsg are already defined in
device/qcom/sepolicy/common/file_contexts

Signed-off-by: Mathieu Maret mmaret@genymobile.com
