### PR TITLE
kitakami: add missing keys

### DIFF
--- a/rootdir/system/usr/keylayout/gpio-keys.kl
+++ b/rootdir/system/usr/keylayout/gpio-keys.kl
@@ -27,3 +27,5 @@
 
 key 115   VOLUME_UP
 key 114   VOLUME_DOWN
+key 528   FOCUS
+key 766   CAMERA


### PR DESCRIPTION
keys definitions for focus and camera buttons

Signed-off-by: David Viteri davidteri91@gmail.com
