### PR TITLE
kitakami: Fix MAC address setting on bluetooth device

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -27,10 +27,6 @@ on init
     mkdir /dev/bus 0755 root root
     mkdir /dev/bus/usb 0755 root root
 
-    # Bluetooth address setting
-    setprop ro.bt.bdaddr_path "/data/etc/bluetooth_bdaddr"
-    chown bluetooth bluetooth ${ro.bt.bdaddr_path}
-
     chown system system /sys/devices/mdss_dsi_panel/panel_id
     chmod 0440 /sys/devices/mdss_dsi_panel/panel_id
 
@@ -389,11 +385,18 @@ service thermanager /system/bin/thermanager /system/etc/thermanager.xml
     user root
     group root
 
-# OSS WLAN setup
+# OSS WLAN and BT MAC setup
 service macaddrsetup /system/bin/macaddrsetup /sys/devices/platform/bcmdhd_wlan/macaddr
-    class main
     user root
+    disabled
     oneshot
+
+on property:vold.post_fs_data_done=1
+    # Generate Bluetooth MAC address file only when /data is ready
+    start macaddrsetup
+    # Wait for the file to be created by macaddrsetup
+    wait /data/etc/bluetooth_bdaddr
+    chown bluetooth bluetooth /data/etc/bluetooth_bdaddr
 
 service wpa_supplicant /system/bin/wpa_supplicant \
     -iwlan0 -Dnl80211 -c/data/misc/wifi/wpa_supplicant.conf \


### PR DESCRIPTION
macaddrsetup generates /data/etc/bluetooth_bdaddr so /data must be ready
to do so.
Wait also for macaddrsetup to generate it and modify its ownership.

Signed-off-by: Humberto Borba humberos@gmail.com
Signed-off-by: Julien Bolard jbolard@genymobile.com
