### PR TITLE
kitakami: Fix Bluedroid bluetooth MAC address reading problem with SE…

### DIFF
--- a/sepolicy/bluetooth.te
+++ b/sepolicy/bluetooth.te
@@ -1,0 +1,2 @@
+# Allow MAC address file reading
+allow bluetooth addrsetup_data_file:file r_file_perms;


### PR DESCRIPTION
…Linux

Add a rule in SELinux to allow it.

Signed-off-by: Humberto Borba humberos@gmail.com
Signed-off-by: Julien Bolard jbolard@genymobile.com
