### PR TITLE
kitakami: SELinux: Add sepolices for touchfusion

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -27,6 +27,7 @@
 /system/vendor/bin/qmuxd                      u:object_r:qmuxd_exec:s0
 /system/vendor/bin/rmt_storage                u:object_r:rmt_storage_exec:s0
 /system/vendor/bin/sensors.qcom               u:object_r:sensors_exec:s0
+/system/vendor/bin/touch_fusion               u:object_r:touchfusion_exec:s0
 
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0
 /sys/devices/platform/bcmdhd_wlan/macaddr               u:object_r:sysfs_addrsetup:s0

--- a/sepolicy/touchfusion.te
+++ b/sepolicy/touchfusion.te
@@ -1,2 +1,51 @@
+# Copyright (c) 2015, The Linux Foundation. All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials provided
+#      with the distribution.
+#    * Neither the name of The Linux Foundation nor the names of its
+#      contributors may be used to endorse or promote products derived
+#      from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Policies for touchfusion
+type touchfusion, domain;
+
+type touchfusion_exec, exec_type, file_type;
+
+init_daemon_domain(touchfusion)
+
+domain_auto_trans(kernel, touchfusion_exec, touchfusion);
+
+allow touchfusion kmsg_device:chr_file rw_file_perms;
+
+allow touchfusion graphics_device:dir r_dir_perms;
+
+allow touchfusion self:netlink_socket create_socket_perms;
+
+allow touchfusion graphics_device:chr_file rw_file_perms;
+
 allow touchfusion cgroup:dir { create add_name };
+
 allow touchfusion self:capability { setgid setuid };
+
+userdebug_or_eng(`
+allow touchfusion self:capability { sys_nice net_admin };
+')


### PR DESCRIPTION
It was removed from upstream but Kitakami (Karin)
needs it.

Signed-off-by: Humberto Borba humberos@gmail.com
