### PR TITLE
kitakami: Fix build

### DIFF
--- a/rootdir/system/etc/data/dsi_config.xml
+++ b/rootdir/system/etc/data/dsi_config.xml
@@ -1,10 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
      DSI Module configuration XML file
      Copyright (c) 2013 Qualcomm Technologies, Inc.  All Rights Reserved.
      Qualcomm Technologies Proprietary and Confidential.
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <list name="dsi_config">
    <!-- Configuration for fusion4.5 PCIe -->
    <listitem name="fusion4_5_pcie">

--- a/rootdir/system/etc/data/netmgr_config.xml
+++ b/rootdir/system/etc/data/netmgr_config.xml
@@ -1,10 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
      Netmgr Module configuration XML file
      Copyright (c) 2013, 2015 Qualcomm Technologies, Inc.  All Rights Reserved.
      Qualcomm Technologies Proprietary and Confidential.
 -->
-
-<?xml version="1.0" encoding="UTF-8"?>
 
 <!-- QMI configuration -->
 <list name="netmgr_config">

--- a/rootdir/system/etc/data/qmi_config.xml
+++ b/rootdir/system/etc/data/qmi_config.xml
@@ -1,10 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
      QMI Module configuration XML file
      Copyright (c) 2013-2014 Qualcomm Technologies, Inc.  All Rights Reserved.
      Qualcomm Technologies Proprietary and Confidential.
 -->
-
-<?xml version="1.0" encoding="UTF-8"?>
 
 <!-- QMI configuration -->
 <list name="qmi_config">


### PR DESCRIPTION
XML declaration allowed only at the start of the document

Copy xml: /android/omni-6.0/out/target/product/karin/system/etc/data/qmi_config.xml
build/core/Makefile:72: recipe for target '/android/omni-6.0/out/target/product/karin/system/etc/data/dsi_config.xml' failed
make: **\* [/android/omni-6.0/out/target/product/karin/system/etc/data/dsi_config.xml] Error 1
make: **\* Waiting for unfinished jobs....
device/sony/kitakami-common/rootdir/system/etc/data/netmgr_config.xml:7: parser error : XML declaration allowed only at the start of the document
<?xml version="1.0" encoding="UTF-8"?>
     ^
build/core/Makefile:72: recipe for target '/android/omni-6.0/out/target/product/karin/system/etc/data/netmgr_config.xml' failed
make: **\* [/android/omni-6.0/out/target/product/karin/system/etc/data/netmgr_config.xml] Error 1
device/sony/kitakami-common/rootdir/system/etc/data/qmi_config.xml:7: parser error : XML declaration allowed only at the start of the document
<?xml version="1.0" encoding="UTF-8"?>
     ^
build/core/Makefile:72: recipe for target '/android/omni-6.0/out/target/product/karin/system/etc/data/qmi_config.xml' failed
make: **\* [/android/omni-6.0/out/target/product/karin/system/etc/data/qmi_config.xml] Error 1

Signed-off-by: Humberto Borba humberos@gmail.com
