### PR TITLE
kitakami: fstab: Update /data and /cache mount options by using AOSP …

### DIFF
--- a/rootdir/fstab.kitakami
+++ b/rootdir/fstab.kitakami
@@ -3,8 +3,8 @@
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
 /dev/block/bootdevice/by-name/system     /system            ext4    ro,barrier=1                                                wait
-/dev/block/bootdevice/by-name/userdata   /data              ext4    rw,nosuid,nodev,noatime,nodiratime,noauto_da_alloc,nobarrier wait,check,formattable,encryptable=footer
-/dev/block/bootdevice/by-name/cache      /cache             ext4    rw,noatime,nosuid,nodev,noatime,barrier=1,data=ordered      wait,check,formattable
+/dev/block/bootdevice/by-name/userdata   /data              ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,discard,errors=panic wait,check,formattable,encryptable=footer
+/dev/block/bootdevice/by-name/cache      /cache             ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,errors=panic wait,check,formattable
 /dev/block/bootdevice/by-name/boot       /boot              emmc    defaults                                                    defaults
 /dev/block/bootdevice/by-name/recovery   /recovery          emmc    defaults                                                    defaults
 /dev/block/bootdevice/by-name/config     /persistent        emmc    defaults                                                    defaults


### PR DESCRIPTION
…angler

---

Revert "kitakami: fstab: Mount /data and /cache as rw"

This reverts commit 16c4bf0578e9d7966bd47d8f35ced2e9d33128ae.

---

kitakami: fstab: Fix typo

this change fixes
https://github.com/sonyxperiadev/device-sony-kitakami/commit/d413b1869652f4753857d812fe7cd4401f06ce21
that includes duplicate noatime instead of nodiratime

Signed-off-by: Humberto Borba humberos@gmail.com

---

Revert "kitakami: fstab: Set /data mount option as nobarrier"

This reverts commit f2309a31ae60e46a11d668d64ede5f3592218785.

---

kitakami: fstab: Update /data and /cache mount options by using AOSP angler as
parameter

https://android.googlesource.com/device/huawei/angler/+/android-6.0.1_r3/fstab.angler

Signed-off-by: Humberto Borba humberos@gmail.com
