### PR TITLE
kitakami: clearpad: add glove permissions

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -186,6 +186,10 @@ on boot
     chown system system /sys/devices/virtual/input/clearpad/cover_win_right
     chown system system /sys/devices/virtual/input/clearpad/cover_win_top
 
+    # Glove mode
+    chown system system /sys/devices/virtual/input/clearpad/glove
+    chmod 0660 /sys/devices/virtual/input/clearpad/glove
+
     # Bring CPUs online
     write /sys/module/msm_thermal/core_control/enabled 0
     write /sys/devices/system/cpu/cpu1/online 1


### PR DESCRIPTION
Not useful right now on aosp but is useful for custom roms which let's the possibility with abstract class make it work
Ex: cmhw (CyanogenMod)

Signed-off-by: David Viteri davidteri91@gmail.com
