### PR TITLE
kitakami: clearpad: add glove permissions

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -158,6 +158,10 @@ on boot
     chmod 0660 /sys/devices/virtual/input/clearpad/wakeup_gesture
     chmod 0660 /sys/devices/virtual/input/maxim_sti/gesture_wakeup
 
+    # Glove mode
+    chown system system /sys/devices/virtual/input/clearpad/glove
+    chmod 0660 /sys/devices/virtual/input/clearpad/glove
+
     # Bluetooth device
     chown bluetooth net_bt_stack /dev/ttyHS0
     chmod 0600 /dev/ttyHS0


### PR DESCRIPTION
Not useful right now on aosp but is useful for custom roms which let's the possibility with abstract class make it work
Ex: cmhw (CyanogenMod)

Signed-off-by: David Viteri davidteri91@gmail.com
