### PR TITLE
kitakami: update file_contexts

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -25,6 +25,7 @@
 /system/vendor/bin/mm-qcamera-daemon          u:object_r:mm-qcamerad_exec:s0
 /system/vendor/bin/netmgrd                    u:object_r:netmgrd_exec:s0
 /system/vendor/bin/qmuxd                      u:object_r:qmuxd_exec:s0
+/system/vendor/bin/rfs_access                 u:object_r:rfs_access_exec:s0
 /system/vendor/bin/rmt_storage                u:object_r:rmt_storage_exec:s0
 /system/vendor/bin/sensors.qcom               u:object_r:sensors_exec:s0
 /system/vendor/bin/touch_fusion               u:object_r:touchfusion_exec:s0


### PR DESCRIPTION
rfs_access needs a policy service on device-qcom-sepolicy is declare
https://github.com/sonyxperiadev/device-qcom-sepolicy/blob/master/common/file_contexts#L155

but it was moved from system/bin to system/vendor/bin

Signed-off-by: David Viteri davidteri91@gmail.com
