### PR TITLE
kitakami: drop TARGET_TAP_TO_WAKE_STRING

### DIFF
--- a/power/Android.mk
+++ b/power/Android.mk
@@ -22,10 +22,6 @@ LOCAL_SRC_FILES := power.c
 
 ifneq ($(TARGET_TAP_TO_WAKE_NODE),)
     LOCAL_CFLAGS += -DTAP_TO_WAKE_NODE=\"$(TARGET_TAP_TO_WAKE_NODE)\"
-
-ifeq ($(TARGET_TAP_TO_WAKE_STRING),true)
-    LOCAL_CFLAGS += -DTAP_TO_WAKE_STRING
-endif
 endif
 
 LOCAL_MODULE := power.kitakami

--- a/power/power.c
+++ b/power/power.c
@@ -97,9 +97,7 @@ void set_feature(struct power_module *module, feature_t feature, int state)
 #ifdef TAP_TO_WAKE_NODE
     if (feature == POWER_FEATURE_DOUBLE_TAP_TO_WAKE) {
             ALOGI("Double tap to wake is %s.", state ? "enabled" : "disabled");
-#ifdef TAP_TO_WAKE_STRING
             sysfs_write(TAP_TO_WAKE_NODE, state ? "1" : "0");
-#endif
         return;
     }
 #endif


### PR DESCRIPTION
it was used on shinano due to sirius path isn't using 1 : 0 for tap to wake feature... here this is not needed

Signed-off-by: David Viteri davidteri91@gmail.com
