### PR TITLE
kitakami: sepolicy: Fix denials

### DIFF
--- a/sepolicy/addrsetup.te
+++ b/sepolicy/addrsetup.te
@@ -15,3 +15,5 @@ allow addrsetup addrsetup_data_file:dir rw_dir_perms;
 allow addrsetup addrsetup_data_file:file create_file_perms;
 
 allow addrsetup sysfs_addrsetup:file rw_file_perms;
+
+allow addrsetup tad_static:unix_stream_socket connectto;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -33,4 +33,7 @@
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0
 
 # Bluetooth
-/sys/devices/soc.0/bluesleep.81/rfkill/rfkill0/state          u:object_r:sysfs_bluetooth_writable:s0
+/proc/bluetooth/sleep/proto                             u:object_r:sysfs_bluetooth_writable:s0
+/proc/bluetooth/sleep/lpm                               u:object_r:sysfs_bluetooth_writable:s0
+/proc/bluetooth/sleep/btwrite                           u:object_r:sysfs_bluetooth_writable:s0
+/sys/devices/soc.0/bluesleep.81/rfkill/rfkill0/state    u:object_r:sysfs_bluetooth_writable:s0

--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -1,1 +1,2 @@
 allow system_app timekeep_prop:property_service set;
+allow system_app system_app_data_file:file { execute };

--- a/sepolicy/tad_static.te
+++ b/sepolicy/tad_static.te
@@ -4,4 +4,4 @@ type tad_static_exec, exec_type, file_type;
 # Started by init
 init_daemon_domain(tad_static)
 
-permissive tad_static;
+allow tad_static block_device:blk_file { ioctl };


### PR DESCRIPTION
[   17.113432] type=1400 audit(9789127.859:5): avc: denied { ioctl } for pid=539 comm="tad_static" path="/dev/block/mmcblk0p1" dev="tmpfs" ino=11013 ioctlcmd=1260 scontext=u:r:tad_static:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file permissive=1
[   17.823629] type=1400 audit(9789128.649:7): avc: denied { connectto } for pid=582 comm="macaddrsetup" path="/dev/socket/tad" scontext=u:r:addrsetup:s0 tcontext=u:r:tad_static:s0 tclass=unix_stream_socket permissive=1

[   37.302801] type=1400 audit(1451958104.469:8): avc: denied { execute } for pid=2016 comm="sh" name="run" dev="mmcblk0p43" ino=458098 scontext=u:r:system_app:s0 tcontext=u:object_r:system_app_data_file:s0 tclass=file permissive=1

---

Also:
- Add/set /proc/bluesleep files as sysfs_bluetooth_writable then
  prevent some bluetooth denials

Signed-off-by: Humberto Borba humberos@gmail.com
