### PR TITLE
kitakami: SELinux for acdb files

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -37,3 +37,6 @@
 /proc/bluetooth/sleep/lpm                               u:object_r:sysfs_bluetooth_writable:s0
 /proc/bluetooth/sleep/btwrite                           u:object_r:sysfs_bluetooth_writable:s0
 /sys/devices/soc.0/bluesleep.81/rfkill/rfkill0/state    u:object_r:sysfs_bluetooth_writable:s0
+
+# acdb delta files
+/data/audio/acdbdata/delta(/.*)?                        u:object_r:system_data_file:s0

--- a/sepolicy/mediaserver.te
+++ b/sepolicy/mediaserver.te
@@ -1,0 +1,1 @@
+allow mediaserver system_data_file:file r_file_perms;


### PR DESCRIPTION
Avoid

   22.277835] type=1400 audit(1453397071.649:11): avc: denied { write } for pid=310 comm=mediaserver name=delta dev=mmcblk0p25 ino=390981 scontext=u:r:mediaserver:s0 tcontext=u:object_r:system_data_file:s0 tclass=dir permissive=1

[   22.277928] type=1400 audit(1453397071.649:12): avc: denied { add_name } for pid=310 comm=mediaserver name=Bluetooth_cal.acdbdelta scontext=u:r:mediaserver:s0 tcontext=u:object_r:system_data_file:s0 tclass=dir permissive=1

[   22.278041] type=1400 audit(1453397071.649:13): avc: denied { create } for pid=310 comm=mediaserver name=Bluetooth_cal.acdbdelta scontext=u:r:mediaserver:s0 tcontext=u:object_r:system_data_file:s0 tclass=file permissive=1

[   22.278129] type=1400 audit(1453397071.649:14): avc: denied { open } for pid=310 comm=mediaserver path=/data/audio/acdbdata/delta/Bluetooth_cal.acdbdelta dev=mmcblk0p25 ino=391097 scontext=u:r:mediaserver:s0 tcontext=u:object_r:system_data_file:s0 tclass=file permissive=1

Note: { append } is neverallow by external/sepolicy... if anybody else fix it feel free to PR :)

Signed-off-by: David Viteri davidteri91@gmail.com
