### PR TITLE
kitakami: init: Use predefined readahead values from kernel

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -160,10 +160,6 @@ on early-boot
     setrlimit 8 67108864 67108864
 
 on boot
-    # Read ahead buffer
-    write /sys/block/mmcblk0/queue/read_ahead_kb 2048
-    write /sys/block/mmcblk1/queue/read_ahead_kb 2048
-
     # PM8941 flash
     chown media system /sys/class/misc/pm8941-flash/device/current1
     chown media system /sys/class/misc/pm8941-flash/device/current2


### PR DESCRIPTION
readahead values:
sonyxperiadev/kernel@02246ee

Signed-off-by: Humberto Borba humberos@gmail.com
