### PR TITLE
kitakami: add system_server.te

### DIFF
--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -1,0 +1,1 @@
+allow system_server init:unix_stream_socket { getopt };


### PR DESCRIPTION
Avoid

[  934.338733] type=1400 audit(1454095513.470:54): avc: denied { getopt } for pid=4032 comm=main path=/dev/socket/zygote scontext=u:r:system_server:s0 tcontext=u:r:init:s0 tclass=unix_stream_socket permissive=1

Signed-off-by: David Viteri davidteri91@gmail.com
