### PR TITLE
kitakami: Remove obsolete sepolicy define

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -75,5 +75,3 @@ TARGET_PER_MGR_ENABLED := true
 # NFC
 NFC_NXP_CHIP_TYPE := PN547C2
 
-# SELinux
-BOARD_SEPOLICY_DIRS += device/sony/kitakami/sepolicy


### PR DESCRIPTION
- No longer needed, moved to device-sony-common.
