### PR TITLE
NFC: Add back lost symlink

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -59,6 +59,10 @@ on boot
     write /dev/cpuset/background/cpus 0
     write /dev/cpuset/system-background/cpus 0-3
 
+    # Symlink for compability
+    symlink /dev/pn54x /dev/pn544
+    symlink /dev/pn54x /dev/pn547
+
 # OSS WLAN and BT MAC setup
 service macaddrsetup /system/bin/macaddrsetup
     user root


### PR DESCRIPTION
HAL is hardwired to look at pn544

Signed-off-by: Adam Farden adam@farden.cz
