### PR TITLE
kitakami: Append cmdline with androidboot.bootdevice

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -39,6 +39,7 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 
 BOARD_KERNEL_CMDLINE += console=ttyHSL0,115200,n8
 BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1 boot_cpus=0-5
+BOARD_KERNEL_CMDLINE += androidboot.bootdevice=f9824900.sdhci
 
 TARGET_KERNEL_ARCH := arm64
 TARGET_KERNEL_HEADER_ARCH := arm64

--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -16,9 +16,6 @@ import init.common.rc
 import init.common.usb.rc
 import init.kitakami.pwr.rc
 
-on init
-    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
-
 on fs
     mount_all ./fstab.kitakami
     restorecon_recursive /persist

--- a/rootdir/init.recovery.kitakami.rc
+++ b/rootdir/init.recovery.kitakami.rc
@@ -1,6 +1,3 @@
-on init
-    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
-
 on boot
     write /sys/class/android_usb/android0/idVendor 0FCE
     write /sys/class/android_usb/android0/idProduct 6${ro.usb.pid_suffix}


### PR DESCRIPTION
Add androidboot.bootdevice=f9824900.sdhci
then remove block symlinks on init.rc files.

bootloader should use that parameter
[f9824900.sdhci for kitakami devices]
and create symlinks automagically.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I4fc64b6e0e39bfb1e2904478751663eeeac1d09e
