### PR TITLE
kitakami: Allow everyone to read /firmware

### DIFF
--- a/rootdir/fstab.kitakami
+++ b/rootdir/fstab.kitakami
@@ -8,7 +8,7 @@
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/recovery     /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
+/dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=222,fmask=222,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /persist     ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic wait,notrim
 
 /devices/soc.0/f98a4900.sdhci/mmc_host/mmc* auto         auto    nosuid,nodev                                      voldmanaged=sdcard1:auto,encryptable=userdata


### PR DESCRIPTION
This should fix the fact that the keymaster firmware isn't
being loaded.
