### PR TITLE
init.kitakami.pwr.rc: Improve for cpu clusters

### DIFF
--- a/rootdir/init.kitakami.pwr.rc
+++ b/rootdir/init.kitakami.pwr.rc
@@ -45,40 +45,35 @@ on charger
     # Enable thermal
     write /sys/module/msm_thermal/core_control/enabled 1
 
-on boot
+on class_start:late_start
     # Disable thermal
     write /sys/module/msm_thermal/core_control/enabled 0
 
-    # Kitakami boots with performance governor.
-    # Switch one core to interactive to set permissions, for power hal and system server.
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
-    chown system system /dev/cpuctl/cpu.notify_on_migrate
-    chmod 0660 /dev/cpuctl/cpu.notify_on_migrate
-    chown root system /sys/devices/system/cpu/cpu1/online
-    chown root system /sys/devices/system/cpu/cpu2/online
-    chown root system /sys/devices/system/cpu/cpu3/online
-    chown root system /sys/devices/system/cpu/cpu4/online
-    chown root system /sys/devices/system/cpu/cpu5/online
-    chown root system /sys/devices/system/cpu/cpu6/online
-    chown root system /sys/devices/system/cpu/cpu7/online
-    chmod 664 /sys/devices/system/cpu/cpu1/online
-    chmod 664 /sys/devices/system/cpu/cpu2/online
-    chmod 664 /sys/devices/system/cpu/cpu3/online
-    chmod 664 /sys/devices/system/cpu/cpu4/online
-    chmod 664 /sys/devices/system/cpu/cpu5/online
-    chmod 664 /sys/devices/system/cpu/cpu6/online
-    chmod 664 /sys/devices/system/cpu/cpu7/online
+    # ensure at most one A57 is online when thermal hotplug is disabled
+    write /sys/devices/system/cpu/cpu5/online 0
+    write /sys/devices/system/cpu/cpu6/online 0
+    write /sys/devices/system/cpu/cpu7/online 0
 
-    # Bring CPUs online
-    write /sys/devices/system/cpu/cpu1/online 1
-    write /sys/devices/system/cpu/cpu2/online 1
-    write /sys/devices/system/cpu/cpu3/online 1
-    write /sys/devices/system/cpu/cpu4/online 1
-    write /sys/devices/system/cpu/cpu5/online 1
-    write /sys/devices/system/cpu/cpu6/online 1
-    write /sys/devices/system/cpu/cpu7/online 1
+    # Allow throttling cpus as a cluster
+    # This is to compensate for the lack of perfd and libqti-perf-client.so
+    write /sys/module/msm_performance/parameters/num_clusters 2
+    write /sys/module/msm_performance/parameters/managed_cpus "0-3"
+    write /sys/module/msm_performance/parameters/managed_cpus "4-7"
 
-on property:init.svc.bootanim=stopped
+    # Limit A57 max freq from msm_perf module in case CPU 4 is offline
+    write /sys/module/msm_performance/parameters/cpu_max_freq "4:960000 5:960000 6:960000 7:960000"
+
+    # disable thermal bcl hotplug
+    write /sys/module/msm_thermal/core_control/enabled 0
+    write /sys/devices/soc.0/qcom,bcl.60/mode "disable"
+    write /sys/devices/soc.0/qcom,bcl.60/hotplug_mask 0
+    write /sys/devices/soc.0/qcom,bcl.60/hotplug_soc_mask 0
+    write /sys/devices/soc.0/qcom,bcl.60/mode "enable"
+    write /sys/devices/soc.0/qcom,bcl.61/mode "disable"
+    write /sys/devices/soc.0/qcom,bcl.61/hotplug_mask 0
+    write /sys/devices/soc.0/qcom,bcl.61/hotplug_soc_mask 0
+    write /sys/devices/soc.0/qcom,bcl.61/mode "enable"
+
     # Configure governor settings for little cluster
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
 
@@ -116,7 +111,7 @@ on property:init.svc.bootanim=stopped
 
     # Configure governor settings for little cluster
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_sched_load 1
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_migration_notif 0
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_migration_notif 1
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay "20000 750000:40000 800000:20000"
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 90
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
@@ -124,19 +119,22 @@ on property:init.svc.bootanim=stopped
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 0
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads "85 780000:90"
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 40000
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/max_freq_hysteresis 80000
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 384000
 
     # Configure governor settings for big cluster
+    write /sys/devices/system/cpu/cpu4/online 1
     write /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor "interactive"
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/use_sched_load 1
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/use_migration_notif 0
+    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/use_migration_notif 1
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/above_hispeed_delay "20000 750000:40000 800000:20000"
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/go_hispeed_load 99
+    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/go_hispeed_load 90
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_rate 20000
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/hispeed_freq 768000
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/io_is_busy 0
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads "85 780000:90"
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/min_sample_time 40000
+    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/max_freq_hysteresis 80000
     write /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 384000
 
     # Userspace control of cpuquiet settings
@@ -150,11 +148,36 @@ on property:init.svc.bootanim=stopped
     write /sys/devices/system/cpu/cpuquiet/nr_power_max_cpus 8
     write /sys/devices/system/cpu/cpuquiet/nr_thermal_max_cpus 8
 
-    # Enable thermal
+    # re-enable thermal and BCL hotplug
     write /sys/module/msm_thermal/core_control/enabled 1
+    write /sys/devices/soc.0/qcom,bcl.60/mode "disable"
+    write /sys/devices/soc.0/qcom,bcl.60/hotplug_mask 192
+    write /sys/devices/soc.0/qcom,bcl.60/hotplug_soc_mask 240
+    write /sys/devices/soc.0/qcom,bcl.60/mode "enable"
+    write /sys/devices/soc.0/qcom,bcl.61/mode "disable"
+    write /sys/devices/soc.0/qcom,bcl.61/hotplug_mask 192
+    write /sys/devices/soc.0/qcom,bcl.61/hotplug_soc_mask 240
+    write /sys/devices/soc.0/qcom,bcl.61/mode "enable"
 
-    # Enable task migration fixups in the scheduler
+    # enable LPM
+    write /sys/module/lpm_levels/parameters/sleep_disabled 0
+
+    # Restore CPU 4 max freq from msm_performance
+    write /sys/module/msm_performance/parameters/cpu_max_freq "4:4294967295 5:4294967295 6:4294967295 7:4294967295"
+
+    # input boost configuration
+    write /sys/module/cpu_boost/parameters/input_boost_freq 1248000
+    write /sys/module/cpu_boost/parameters/input_boost_ms 40
+
+    # Setting b.L scheduler parameters
     write /proc/sys/kernel/sched_migration_fixup 1
+    write /proc/sys/kernel/sched_small_task 30
+    write /proc/sys/kernel/sched_mostly_idle_load 20
+    write /proc/sys/kernel/sched_mostly_idle_nr_run 3
+    write /proc/sys/kernel/sched_upmigrate 99
+    write /proc/sys/kernel/sched_downmigrate 85
+    write /proc/sys/kernel/sched_freq_inc_notify 400000
+    write /proc/sys/kernel/sched_freq_dec_notify 400000
 
     # Android background processes are set to nice 10
     # Never schedule these on the A57
@@ -166,7 +189,3 @@ on property:init.svc.bootanim=stopped
 
     write /sys/class/kgsl/kgsl-3d0/devfreq/governor "msm-adreno-tz"
     write /dev/cpuctl/cpu.notify_on_migrate 1
-
-on property:sys.boot_completed=1
-    # Allow CPUs to go in deeper idle state than C0
-    write /sys/module/lpm_levels/parameters/sleep_disabled 0

--- a/rootdir/ueventd.kitakami.rc
+++ b/rootdir/ueventd.kitakami.rc
@@ -134,6 +134,7 @@
 # Thermanager
 /sys/module/msm_performance/parameters/cpu_max_freq   0664 system system
 /sys/module/msm_performance/parameters/cpu_min_freq   0664 system system
+/sys/module/msm_performance/parameters/max_cpus       0664 system system
 
 /sys/devices/virtual/graphics/fb1/avi_itc             0664 system graphics
 /sys/devices/virtual/graphics/fb1/avi_cn0_1           0664 system graphics


### PR DESCRIPTION
Correctly init the msm_performance module to allow
thermanager to throttle by cluster.

Signed-off-by: Adam Farden adam@farden.cz
