### PR TITLE
kitakami: re-add media_codecs_performance.xml

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -26,6 +26,7 @@ PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/system/etc/audio_platform_info.xml:system/etc/audio_platform_info.xml \
     $(SONY_ROOT)/system/etc/audio_platform_info_i2s.xml:system/etc/audio_platform_info_i2s.xml \
     $(SONY_ROOT)/system/etc/media_codecs.xml:system/etc/media_codecs.xml \
+    $(SONY_ROOT)/system/etc/media_codecs_performance.xml:system/etc/media_codecs_performance.xml \
     $(SONY_ROOT)/system/etc/media_profiles.xml:system/etc/media_profiles.xml
 
 # Broadcom BT

--- a/rootdir/system/etc/media_codecs_performance.xml
+++ b/rootdir/system/etc/media_codecs_performance.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2015 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<MediaCodecs>
+    <Encoders>
+        <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="456-456" />
+            <Limit name="measured-frame-rate-720x480" range="198-198" />
+            <Limit name="measured-frame-rate-1280x720" range="94-94" />
+            <Limit name="measured-frame-rate-1920x1080" range="43-43" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.h263" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="547-547" />
+            <Limit name="measured-frame-rate-352x288" range="360-360" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.mpeg4" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="509-509" />
+            <Limit name="measured-frame-rate-352x288" range="363-363" />
+            <Limit name="measured-frame-rate-640x480" range="172-172" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.vp8" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="163-163" />
+            <Limit name="measured-frame-rate-640x360" range="144-144" />
+            <Limit name="measured-frame-rate-1280x720" range="70-70" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h264.encoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="452-452" />
+            <Limit name="measured-frame-rate-720x480" range="93-93" />
+            <Limit name="measured-frame-rate-1280x720" range="46-46" />
+            <Limit name="measured-frame-rate-1920x1080" range="19-19" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h263.encoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="607-607" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.mpeg4.encoder" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="567-567" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.vp8.encoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="180-180" />
+            <Limit name="measured-frame-rate-640x360" range="120-120" />
+            <Limit name="measured-frame-rate-1280x720" range="31-31" />
+            <Limit name="measured-frame-rate-1920x1080" range="21-21" />
+        </MediaCodec>
+    </Encoders>
+    <Decoders>
+        <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="587-587" />
+            <Limit name="measured-frame-rate-720x480" range="357-357" />
+            <Limit name="measured-frame-rate-1280x720" range="155-155" />
+            <Limit name="measured-frame-rate-1920x1088" range="80-80" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.h263" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="960-960" />
+            <Limit name="measured-frame-rate-352x288" range="770-770" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.hevc" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-352x288" range="679-679" />
+            <Limit name="measured-frame-rate-640x360" range="565-565" />
+            <Limit name="measured-frame-rate-1280x720" range="375-375" />
+            <Limit name="measured-frame-rate-1920x1080" range="205-205" />
+            <Limit name="measured-frame-rate-3840x2160" range="60-60" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.mpeg4" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-480x360" range="720-720" />
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.vp8" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="545-545" />
+            <Limit name="measured-frame-rate-640x360" range="520-520" />
+            <Limit name="measured-frame-rate-1280x720" range="566-566" />
+            <Limit name="measured-frame-rate-1920x1080" range="368-368" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h264.decoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="849-849" />
+            <Limit name="measured-frame-rate-720x480" range="230-230" />
+            <Limit name="measured-frame-rate-1280x720" range="103-103" />
+            <Limit name="measured-frame-rate-1920x1080" range="46-46" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h263.decoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="882-882" />
+            <Limit name="measured-frame-rate-352x288" range="875-875" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.hevc.decoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-352x288" range="644-644" />
+            <Limit name="measured-frame-rate-640x360" range="332-332" />
+            <Limit name="measured-frame-rate-1280x720" range="140-140" />
+            <Limit name="measured-frame-rate-1920x1080" range="76-76" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.vp8.decoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="1005-1005" />
+            <Limit name="measured-frame-rate-640x360" range="342-342" />
+            <Limit name="measured-frame-rate-1280x720" range="62-62" />
+            <Limit name="measured-frame-rate-1920x1080" range="51-51" />
+        </MediaCodec>
+        <MediaCodec name="OMX.google.vp9.decoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x180" range="407-407" />
+            <Limit name="measured-frame-rate-640x360" range="336-336" />
+            <Limit name="measured-frame-rate-1280x720" range="131-131" />
+            <Limit name="measured-frame-rate-1920x1080" range="77-77" />
+        </MediaCodec>
+    </Decoders>
+</MediaCodecs>


### PR DESCRIPTION
this was removed durin device-sony-common repo also is needed by system

log:

MediaCodecList: Unable to open media codecs configuration xml file: /data/misc/media/media_cedecs_profiling_results.xml

picked from Angler

Signed-off-by: David Viteri davidteri91@gmail.com
