### PR TITLE
kitakami: overlay: Add lid cover power control

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate. -->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- Indicate whether closing the lid causes the device to go to sleep and opening
+         it causes the device to wake up.
+         The default is false. -->
+    <bool name="config_lidControlsSleep">true</bool>
+
+</resources>

--- a/platform.mk
+++ b/platform.mk
@@ -20,6 +20,10 @@ SOMC_PLATFORM := kitakami
 
 SONY_ROOT := device/sony/kitakami/rootdir
 
+# Common Overlay
+DEVICE_PACKAGE_OVERLAYS += \
+    device/sony/kitakami/overlay
+
 # Media
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/system/etc/aanc_tuning_mixer.txt:system/etc/aanc_tuning_mixer.txt \


### PR DESCRIPTION
This overlay entry indicates whether closing the lid
causes the device to go to sleep and opening it causes
the device to wake up.

Kernel driver is fixed:
https://github.com/sonyxperiadev/kernel/commit/8b6dc10acf3a0e7545d84427d8022c365d8ea03d

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I72b25d4a5d153151dbee4e501a0d29e98136a5f8
