### PR TITLE
kitakami: Fix simple power HAL permissions

### DIFF
--- a/rootdir/init.kitakami.pwr.rc
+++ b/rootdir/init.kitakami.pwr.rc
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+on init
+    # cpuquiet rqbalance permissions
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+
 on charger
     # Disable thermal
     write /sys/module/msm_thermal/core_control/enabled 0
@@ -24,14 +33,6 @@ on charger
     write /sys/devices/system/cpu/cpu5/online 1
     write /sys/devices/system/cpu/cpu6/online 1
     write /sys/devices/system/cpu/cpu7/online 1
-
-    # cpuquiet rqbalance permissions
-    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
-    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
-    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
-    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
-    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
-    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
 
     # Configure governor settings for little cluster
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "powersave"


### PR DESCRIPTION
Fix and move simple power HAL permissions to "on init" stage
then it will also be able early to LPM mode.

Fix:

05-16 10:39:00.817  1027  1048 I Simple PowerHAL: Device is asleep.
05-16 10:39:00.817  1027  1048 I Simple PowerHAL: Setting low power mode
05-16 10:39:00.817  1027  1048 E Simple PowerHAL: Error opening /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level: Permission denied
05-16 10:39:00.817  1027  1048 E Simple PowerHAL: Error opening /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds: Permission denied
05-16 10:39:00.817  1027  1048 E Simple PowerHAL: Error opening /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds: Permission denied

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ia2e82d778dbe7d8a8c69630c8f1ca52fddf42d7a
