### PR TITLE
fixup overlay override

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -61,7 +61,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.sensor.barometer.xml:system/etc/permissions/android.hardware.sensor.barometer.xml \
     frameworks/native/data/etc/android.hardware.nfc.hce.xml:system/etc/permissions/android.hardware.nfc.hce.xml
 
-DEVICE_PACKAGE_OVERLAYS := \
+DEVICE_PACKAGE_OVERLAYS += \
     device/sony/kitakami/overlay
 
 # Platform Init


### PR DESCRIPTION
the order of config calls is
*device (lets say sumire) -> kitakami -> common

as sumire defines overlays already, we need to use += on the kitakami
repo, else we're overriding the sumire overlay includes.
