### PR TITLE
Kitakami: use correct path for recovery partition

### DIFF
--- a/rootdir/fstab.kitakami
+++ b/rootdir/fstab.kitakami
@@ -6,7 +6,7 @@
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,errors=panic wait,check,formattable
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,discard,errors=panic wait,check,formattable,encryptable=footer
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/recovery     /recovery    emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=222,fmask=222,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /persist     ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic wait,notrim


### PR DESCRIPTION
FOTAKernel -> /dev/block/mmcblk0p32

Signed-off-by: David Viteri davidteri91@gmail.com
