### PR TITLE
kitakami: use the not custom KEY_POWER for clearpad wakeup gesture

### DIFF
--- a/rootdir/system/usr/keylayout/clearpad.kl
+++ b/rootdir/system/usr/keylayout/clearpad.kl
@@ -1,1 +1,1 @@
-key 531	WAKEUP
+key 116	KEY_POWER


### PR DESCRIPTION
the kernel uses KEY_POWER for this function
https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BR.1.3.3_rb2.14/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi#L224
