### PR TITLE
[master] sony: kitakami: Set BT default name dynamically

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -17,6 +17,35 @@
 #ifndef _BDROID_BUILDCFG_H
 #define _BDROID_BUILDCFG_H
 
+#if !defined(OS_GENERIC)
+#include <cutils/properties.h>
+#include <string.h>
+
+static inline const char* getBTDefaultName()
+{
+    char device[PROPERTY_VALUE_MAX];
+    property_get("ro.boot.hardware", device, "");
+
+    if (!strcmp("ivy", device)) {
+        return "Xperia Z3+";
+    } else if (!strcmp("karin", device)) {
+        return "Xperia Z4 Tablet";
+    } else if (!strcmp("karin_windy", device)) {
+        return "Xperia Z4 Tablet";
+    } else if (!strcmp("sumire", device)) {
+        return "Xperia Z5";
+    } else if (!strcmp("suzuran", device)) {
+        return "Xperia Z5 Compact";
+    } else if (!strcmp("satsuki", device)) {
+        return "Xperia Z5 Premium";
+    }
+
+    return "Xperia";
+}
+
+#define BTM_DEF_LOCAL_NAME getBTDefaultName()
+#endif // OS_GENERIC
+
 /* #define BTA_AV_CO_CP_SCMS_T   TRUE */
 #define SDP_AVRCP_1_5   FALSE
 


### PR DESCRIPTION
Use ro.boot.hardware property and naming BT dynamically.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I5dddc4698c958cf12eccc349f96a9a4ac83f9d6c
