### PR TITLE
Update bt_vendor.conf to work with v4l2(fm/ant)

### DIFF
--- a/rootdir/system/etc/bluetooth/bt_vendor.conf
+++ b/rootdir/system/etc/bluetooth/bt_vendor.conf
@@ -1,6 +1,14 @@
 # UART device port where Bluetooth controller is attached
 UartPort = /dev/ttyHS0
 
+# Target Baudrate to change to if different from 3000000
+# This entry is mandatory if using V4L2
+UartBaudRate = 3000000
+
 # Firmware patch file location
 FwPatchFilePath = /system/etc/firmware/
 FwPatchFileName = BCM43xx.hcd
+
+# Firmware patch setttlement delay in millisec
+# This entry is mandatory if using V4L2
+FwPatchSettlementDelay = 100


### PR DESCRIPTION
Changes needed, to get work brcm-uim-sysfs daemon and fm radio/ant.
