### PR TITLE
sony: kitakami: Add proximity dependencies

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -122,6 +122,12 @@ service fingerprintd /system/bin/fingerprintd
     user system
     group input
 
+# AD7146 Proximity Sensor
+service pad_controller /system/vendor/bin/pad_controller
+    class late_start
+    user system
+    group system radio
+
 service msm_irqbalance /system/vendor/bin/msm_irqbalance -f /system/etc/msm_irqbalance.conf
     socket msm_irqbalance seqpacket 660 root system
     class core

--- a/rootdir/ueventd.kitakami.rc
+++ b/rootdir/ueventd.kitakami.rc
@@ -111,6 +111,19 @@
 /sys/devices/virtual/switch/hdmi_audio  state       0660 system system
 /sys/devices/virtual/switch/wfd         state       0660 system system
 
+# AD7146
+/sys/devices/virtual/cap_sensor/ad7146 dac_calibrate  0660 system system
+/sys/devices/virtual/cap_sensor/ad7146 dac_mid_val    0660 system system
+/sys/devices/virtual/cap_sensor/ad7146 force_calib    0220 system system
+/sys/devices/virtual/cap_sensor/ad7146 obj_detect     0660 system system
+/sys/devices/virtual/cap_sensor/ad7146 pad_set        0220 system system
+/sys/devices/virtual/cap_sensor/ad7146 pad_num        0220 system system
+/sys/devices/virtual/cap_sensor/ad7146 pad_data       0440 system system
+/sys/devices/virtual/cap_sensor/ad7146 pad_offset     0660 system system
+/sys/devices/virtual/cap_sensor/ad7146 sw_updata      0440 system system
+/sys/devices/virtual/switch/ad7146     state          0660 system system
+/sys/devices/virtual/switch/ad7146_*   state          0660 system system
+
 # NFC
 /dev/nfc-nci                                        0660 nfc nfc
 /dev/pn544                                          0660 nfc nfc

--- a/system.prop
+++ b/system.prop
@@ -13,3 +13,9 @@ cpuquiet.normal.max_cpus=8
 rqbalance.normal.balance_level=40
 rqbalance.normal.up_threshold=100 300 400 500 525 600 700 4294967295
 rqbalance.normal.down_threshold=0 100 300 400 425 500 600 650
+
+#
+# AD7146
+# PAD controller
+service.pad1.control.start=pad1_on
+service.pad2.control.start=pad2_on


### PR DESCRIPTION
It is required for AD7146 proximity driver.

Signed-off-by: Humberto Borba humberos@gmail.com
