### PR TITLE
[URGENT] kitakami: Fix rqbalance downcore thresholds

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -12,4 +12,4 @@ cpuquiet.normal.min_cpus=2
 cpuquiet.normal.max_cpus=8
 rqbalance.normal.balance_level=40
 rqbalance.normal.up_threshold=100 300 380 400 500 575 625 4294967295
-rqbalance.normal.down_threshold=0 100 300 400 425 500 550 650
+rqbalance.normal.down_threshold=0 70 200 280 330 450 515 585


### PR DESCRIPTION
Last commit fixing kitakami rqbalance tuned the upcore
thresholds, but not the downcore ones, resulting in a
balancing algorithm mistake that, in some particular
conditions, was calling downcore even if load was
effectively optimal for the previous number of online
cores.

This was not impacting on performance but on power
efficiency, as the remaining online CPUs' clocks were
being bumped up to keep system performance high for UX.
