### PR TITLE
macaddr: remove dangerous sepolicy permissions

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -25,6 +25,9 @@ on fs
     write /sys/kernel/boot_adsp/boot 1
 
 on boot
+    # Bluetooth
+    chown system system /sys/devices/soc.0/bcmdhd_wlan.90/macaddr
+
     # Cover mode
     chown system system /sys/devices/virtual/input/clearpad/cover_mode_enabled
     chown system system /sys/devices/virtual/input/clearpad/cover_win_bottom
@@ -83,9 +86,12 @@ on boot
 
 # OSS WLAN and BT MAC setup
 service macaddrsetup /system/bin/macaddrsetup /sys/devices/soc.0/bcmdhd_wlan.90/macaddr
-    user root
+    class core
+    user system
+    group system bluetooth
     disabled
     oneshot
+    writepid /dev/cpuset/system-background/tasks
 
 service wpa_supplicant /system/bin/wpa_supplicant \
     -iwlan0 -Dnl80211 -c/data/misc/wifi/wpa_supplicant.conf \
@@ -165,9 +171,6 @@ service uim /system/bin/brcm-uim-sysfs
 on property:vold.post_fs_data_done=1
     # Generate Bluetooth MAC address file only when /data is ready
     start macaddrsetup
-    # Wait for the file to be created by macaddrsetup
-    wait /data/etc/bluetooth_bdaddr
-    chown bluetooth bluetooth /data/etc/bluetooth_bdaddr
 
 on property:bluetooth.isEnabled=true
     write /sys/class/bluetooth/hci0/idle_timeout 7000


### PR DESCRIPTION
Write the bluetooth macaddr to a place that is natively readable
by bluetooth services, instead of creating new locations which
requires excessive permissions.

Signed-off-by: Adam Farden adam@farden.cz
