### PR TITLE
[DO NOT MERGE][REFERENCE]kitakami: ueventd: fix leds paths

### DIFF
--- a/rootdir/ueventd.kitakami.rc
+++ b/rootdir/ueventd.kitakami.rc
@@ -123,13 +123,13 @@
 /sys/devices/f9928000.i2c/i2c-6/6-0028  send_cmd    0200 nfc nfc
 
 # LED
-/sys/devices/soc.0/03-qcom,leds-d000/leds/led:* max_brightness          0664 system system
-/sys/devices/soc.0/03-qcom,leds-d000/leds/led:* brightness              0664 system system
-/sys/devices/soc.0/03-qcom,leds-d000/leds/led:* blink                   0664 system system
-/sys/devices/soc.0/03-qcom,leds-d000/leds/led:* duty_pcts               0664 system system
-/sys/devices/soc.0/03-qcom,leds-d000/leds/led:* ramp_step_ms            0664 system system
-/sys/devices/soc.0/03-qcom,leds-d800/leds/wled:backlight max_brightness 0664 system system
-/sys/devices/soc.0/03-qcom,leds-d800/leds/wled:backlight brightness     0664 system system
+/sys/devices/soc.0/leds-qpnp-26/leds/led:* max_brightness               0664 system system
+/sys/devices/soc.0/leds-qpnp-26/leds/led:* brightness                   0664 system system
+/sys/devices/soc.0/leds-qpnp-26/leds/led:* blink                        0664 system system
+/sys/devices/soc.0/leds-qpnp-26/leds/led:* duty_pcts                    0664 system system
+/sys/devices/soc.0/leds-qpnp-26/leds/led:* ramp_step_ms                 0664 system system
+/sys/devices/soc.0/qpnp-wled-24/leds/wled  max_brightness               0664 system system
+/sys/devices/soc.0/qpnp-wled-24/leds/wled  brightness                   0664 system system
 /sys/class/leds/lcd-backlight/max_brightness                            0644 root system
 /sys/class/leds/lcd-backlight/brightness                                0664 system system
 


### PR DESCRIPTION
due to kernel spmi update

Signed-off-by: David Viteri <davidteri91@gmail.com>