### PR TITLE
[WIP - n-mr0] BT/FMRadio using the broadcom ldisc driver

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -21,6 +21,8 @@
 #include <cutils/properties.h>
 #include <string.h>
 
+#define HCILP_INCLUDED FALSE
+
 static inline const char* getBTDefaultName()
 {
     char device[PROPERTY_VALUE_MAX];

--- a/rootdir/system/etc/bluetooth/bt_vendor.conf
+++ b/rootdir/system/etc/bluetooth/bt_vendor.conf
@@ -1,5 +1,11 @@
 # UART device port where Bluetooth controller is attached
-UartPort = /dev/ttyHS0
+# (intrface to libbt)
+UartPort = /dev/brcm_bt_drv
+
+# UART device port of the chip's driver for Uim. UartPort can be
+# a wrapper of this port (e.g., for combined BT/FM chips) used in
+# libbt.
+UimUartPort = /dev/ttyHS0
 
 # Target Baudrate to change to if different from 3000000
 # This entry is mandatory if using V4L2


### PR DESCRIPTION
Please see sonyxperiadev/kernel#1162

This is the required user space modification (2/2) for combined BT/FMRadio support via the broadcom ldisc driver.