### PR TITLE
sony: kitakami: Move BT flag

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -21,8 +21,6 @@
 #include <cutils/properties.h>
 #include <string.h>
 
-#define HCILP_INCLUDED FALSE
-
 static inline const char* getBTDefaultName()
 {
     char device[PROPERTY_VALUE_MAX];
@@ -47,6 +45,8 @@ static inline const char* getBTDefaultName()
 
 #define BTM_DEF_LOCAL_NAME getBTDefaultName()
 #endif // OS_GENERIC
+
+#define HCILP_INCLUDED FALSE
 
 /* #define BTA_AV_CO_CP_SCMS_T   TRUE */
 #define SDP_AVRCP_1_5   FALSE


### PR DESCRIPTION
Move HCILP_INCLUDED out of OS_GENERIC #ifdef .

OS_GENERIC flag was used to fix BTDefaultName at Nougat.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ibd6784d03aac698743ef79023d0ef14604d8ea46