### PR TITLE
sony: kitakami: Increase max number of compression streams

### DIFF
--- a/rootdir/init.kitakami.rc
+++ b/rootdir/init.kitakami.rc
@@ -17,9 +17,11 @@ import init.common.usb-legacy.rc
 import init.kitakami.pwr.rc
 
 on init
-    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
+    write /sys/block/zram0/max_comp_streams 8
 
 on fs
+    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
+
     mount_all ./fstab.kitakami
     swapon_all ./fstab.kitakami
 


### PR DESCRIPTION
Regardless the value passed to this attribute, ZRAM will always
allocate multiple compression streams - one per online CPUs - thus
allowing several concurrent compression operations. The number of
allocated compression streams goes down when some of the CPUs
become offline. There is no single-compression-stream mode anymore,
unless you are running a UP system or has only 1 CPU online.

Change-Id: I8997d92265308c962e0ac9b4119be567c4898988
Signed-off-by: Humberto Borba <humberos@gmail.com>